### PR TITLE
Adding Timestamp to sensor_msgs/Image and Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ The `camera_pkg_launch.py` included in this package provides an example demonstr
                     executable='camera_node',
                     name='camera_node'
                     parameters=[
-                        {'resize_images': 4},
+                        {'resize_images': True},
+                        {'resize_images_factor': 4},
+                        {'fps': 0},
                         {'display_topic_enable': True}
                 ]
                 )
@@ -132,7 +134,9 @@ The `camera_pkg_launch.py` included in this package provides an example demonstr
 
 | Parameter name   | Description  |
 | ---------------- |  ----------- |
-| `resize_images` | Set to positive integer depending on if you want to resize the images in camera_pkg. Use 1 for no resizing |
+| `resize_images` | Set to `True` or `False` depending on if you want to resize the images in camera_pkg |
+| `resize_images_factor` | Will downscale the image with a factor. Default is 4 to create 160 x 120 pixel image |
+| `fps` | Will limit the number of pictures per second that are captured. Default value is 0 which will let camera control frames per second | 
 | `display_topic_enable` | Set to true if you want to enable the `camera_pkg`/`display_mjpeg` topic |
 
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ The `camera_pkg_launch.py` included in this package provides an example demonstr
                     executable='camera_node',
                     name='camera_node'
                     parameters=[
-                        {'resize_images': False}
+                        {'resize_images': 4},
+                        {'display_topic_enable': True}
                 ]
                 )
             ])
@@ -131,7 +132,8 @@ The `camera_pkg_launch.py` included in this package provides an example demonstr
 
 | Parameter name   | Description  |
 | ---------------- |  ----------- |
-| `resize_images` | Set to `True` or `False` depending on if you want to resize the images in camera_pkg |
+| `resize_images` | Set to positive integer depending on if you want to resize the images in camera_pkg. Use 1 for no resizing |
+| `display_topic_enable` | Set to true if you want to enable the `camera_pkg`/`display_mjpeg` topic |
 
 
 ## Node details

--- a/camera_pkg/launch/camera_pkg_launch.py
+++ b/camera_pkg/launch/camera_pkg_launch.py
@@ -26,7 +26,8 @@ def generate_launch_description():
             executable='camera_node',
             name='camera_node',
             parameters=[
-                {'resize_images': True}
+                {'resize_images': 4},
+                {'display_topic_enable': True}
             ]
         )
     ])

--- a/camera_pkg/launch/camera_pkg_launch.py
+++ b/camera_pkg/launch/camera_pkg_launch.py
@@ -26,7 +26,9 @@ def generate_launch_description():
             executable='camera_node',
             name='camera_node',
             parameters=[
-                {'resize_images': 4},
+                {'resize_images': True},
+                {'resize_images_factor': 4},
+                {'fps': 0},
                 {'display_topic_enable': True}
             ]
         )

--- a/camera_pkg/src/camera_node.cpp
+++ b/camera_pkg/src/camera_node.cpp
@@ -134,6 +134,9 @@ namespace MediaEng {
         void produceFrames() {
             while (produceFrames_) {
                 deepracer_interfaces_pkg::msg::CameraMsg msg;
+                std_msgs::msg::Header header;
+                header.stamp = this->get_clock()->now();
+
                 for (auto& cap :  videoCaptureList_) {
                     if (!cap.isOpened()) {
                         continue;
@@ -145,7 +148,7 @@ namespace MediaEng {
                         continue;
                     }
                     try {
-                            msg.images.push_back(*(cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", frame).toImageMsg().get()));
+                            msg.images.push_back(*(cv_bridge::CvImage(header, "bgr8", frame).toImageMsg().get()));
                     }
                     catch (cv_bridge::Exception& e) {
                         RCLCPP_ERROR(this->get_logger(), "cv_bridge exception: %s", e.what());

--- a/camera_pkg/src/camera_node.cpp
+++ b/camera_pkg/src/camera_node.cpp
@@ -26,8 +26,8 @@
 #include <memory>
 
 namespace MediaEng {
-    #define DEFAULT_IMAGE_WIDTH 160
-    #define DEFAULT_IMAGE_HEIGHT 120
+    #define DEFAULT_IMAGE_WIDTH 640
+    #define DEFAULT_IMAGE_HEIGHT 480
     class CameraNode : public rclcpp::Node
     {
     /// This class creates the camera_node responsible to read data from the cameras
@@ -43,12 +43,18 @@ namespace MediaEng {
         CameraNode(const std::string & node_name, const std::vector<int> cameraIdxList)
         : Node(node_name),
         produceFrames_(false),
-        resizeImages_(true)
+        downscaleImages_(4),
+        enableDisplayPub_(true)
         {
             RCLCPP_INFO(this->get_logger(), "%s started", node_name.c_str());
-            this->declare_parameter<bool>("resize_images", resizeImages_);
-            // Update resizeImages boolean based on the parameter
-            resizeImages_ = this->get_parameter("resize_images").as_bool();
+            this->declare_parameter<int>("downscale_images", downscaleImages_);
+            // Update downscaleImages int based on the parameter
+            downscaleImages_ = this->get_parameter("downscale_images").as_int();
+
+            this->declare_parameter<bool>("display_topic_enable", enableDisplayPub_);
+            // Enable the Display Msg Topic
+            enableDisplayPub_ = this->get_parameter("display_topic_enable").as_bool();
+
 
             // Scan and load only valid streamers to Video Capture list.
             scanCameraIndex(cameraIdxList);
@@ -60,7 +66,8 @@ namespace MediaEng {
             // This displays only the left/center camera images. Modify if the requirement is to publish images from both cameras.
             // The queue size for displayPub_ is set to 10 because web_video_server subscribes to the camera_node and the 
             // image callback is blocked since it probably expects to send a frame which has been lost due to small publisher queue size of 1 earlier.
-            displayPub_ = this->create_publisher<sensor_msgs::msg::Image>(DISPLAY_MSG_TOPIC, 10);
+            if (enableDisplayPub_)
+                displayPub_ = this->create_publisher<sensor_msgs::msg::Image>(DISPLAY_MSG_TOPIC, 10);
             
             // Create a service to activate the publish of camera images.
             activateCameraService_ = this->create_service<deepracer_interfaces_pkg::srv::VideoStateSrv>(
@@ -153,8 +160,8 @@ namespace MediaEng {
                         continue;
                     }
                     try {
-                        if(resizeImages_) {
-                            cv::resize(frame, frame, cv::Size(DEFAULT_IMAGE_WIDTH, DEFAULT_IMAGE_HEIGHT));
+                        if(downscaleImages_ > 1) {
+                            cv::resize(frame, frame, cv::Size((int) DEFAULT_IMAGE_WIDTH / downscaleImages_, (int) DEFAULT_IMAGE_HEIGHT / downscaleImages_));
                         }
                         msg.images.push_back(*(cv_bridge::CvImage(header, "bgr8", frame).toImageMsg().get()));
                     }
@@ -165,7 +172,8 @@ namespace MediaEng {
                     }
                 }
                 try {
-                    displayPub_->publish(msg.images.front());
+                    if (enableDisplayPub_)
+                        displayPub_->publish(msg.images.front());
                     videoPub_->publish(msg);
                 }
                     catch (const std::exception &ex) {
@@ -182,8 +190,10 @@ namespace MediaEng {
         rclcpp::Service<deepracer_interfaces_pkg::srv::VideoStateSrv>::SharedPtr activateCameraService_;
         /// Boolean for starting and stopping the worker thread.
         std::atomic<bool> produceFrames_;
-        /// Boolean to resize images.
-        std::atomic<bool> resizeImages_;
+        /// Factor (int) to downscale images.
+        std::atomic<int64_t> downscaleImages_;
+        /// Boolean for enabling the display mpeg topic.
+        std::atomic<bool> enableDisplayPub_;        
         /// List of OpenCV video capture object used to retrieve frames from the cameras.
         std::vector<cv::VideoCapture> videoCaptureList_;
         /// List of valid camera indices identified after scanning.

--- a/camera_pkg/src/camera_node.cpp
+++ b/camera_pkg/src/camera_node.cpp
@@ -163,7 +163,6 @@ namespace MediaEng {
             while (produceFrames_) {
                 deepracer_interfaces_pkg::msg::CameraMsg msg;
                 std_msgs::msg::Header header;
-                header.stamp = this->get_clock()->now();
                 header.frame_id = std::to_string(imageFrameId_++);
                 for (auto& cap :  videoCaptureList_) {
                     if (!cap.isOpened()) {
@@ -171,6 +170,7 @@ namespace MediaEng {
                     }
                     cv::Mat frame;
                     cap >> frame;
+                    header.stamp = this->get_clock()->now();
                     if (frame.empty()) {
                         RCLCPP_ERROR(this->get_logger(), "No frame returned. Check if camera is plugged in correctly.");
                         continue;


### PR DESCRIPTION
**Issue Number** (if available): N/A

**Description of changes:**
* Populating the message header with a timestamp and unique identifier to allow for more accurate video production downstream.
* Add a parameter to define the rescaling factor
* Add a parameter to limit the number of frames per second to be produced
* Add a parameter to turn off the display stream
--

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
